### PR TITLE
refactor: extract useLog hook to dedicated file

### DIFF
--- a/app/(tabs)/index.tsx
+++ b/app/(tabs)/index.tsx
@@ -48,9 +48,10 @@ export default function HomeScreen() {
 
   const fetchHello = useFetchHello();
 
-  useLogjam("hello");
+  useLog("hello");
 
-  useLogjam({ example: "hello" });
+  // Example with object
+  useLog({ example: "hello" });
 
   return (
     <ScrollView style={{ padding: insets.top }}>

--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -12,7 +12,8 @@ import * as SplashScreen from "expo-splash-screen";
 import { StatusBar } from "expo-status-bar";
 import { useEffect } from "react";
 import "react-native-reanimated";
-import "../util/logjam"; // relative path for reliable module resolution
+import "../hooks/useLog"; // import useLog hook for global registration
+import "../util/log"; // relative path for reliable module resolution
 
 // prevent the splash screen from auto-hiding before asset loading is complete
 SplashScreen.preventAutoHideAsync();

--- a/hooks/useLog.ts
+++ b/hooks/useLog.ts
@@ -1,0 +1,14 @@
+import { useEffect } from "react";
+import type { LoggableRecord, UseLog } from "../types/log";
+import { log } from "../util/log";
+
+export const useLog: UseLog = (vars: string | LoggableRecord) => {
+  useEffect(() => {
+    log(vars);
+  }, [vars]);
+};
+
+// Ensure we're in a JS environment with globalThis
+if (typeof globalThis !== "undefined") {
+  globalThis.useLog = useLog;
+}

--- a/types/log.d.ts
+++ b/types/log.d.ts
@@ -15,15 +15,15 @@ export type LoggableValue =
 export type LoggableRecord = Record<string, LoggableValue>;
 
 /**
- * Function signature for the logjam logger
+ * Function signature for the logger
  */
-export type LogjamFunction = (vars: string | LoggableRecord) => void;
+export type Log = (vars: string | LoggableRecord) => void;
 
-export type UseLogger = (vars: string | LoggableRecord) => void;
+export type UseLog = (vars: string | LoggableRecord) => void;
 
 declare global {
-  var logjam: LogjamFunction;
-  var useLogjam: UseLogger;
+  var log: Log;
+  var useLog: UseLog;
 }
 
 export {};

--- a/util/log.ts
+++ b/util/log.ts
@@ -1,10 +1,4 @@
-import { useEffect } from "react";
-import type {
-  LoggableRecord,
-  LoggableValue,
-  UseLogger,
-  LogjamFunction,
-} from "../types/logjam";
+import type { Log, LoggableRecord, LoggableValue } from "../types/log";
 
 const logWithDivider = (key: string, value: LoggableValue) => {
   console.log("..................................");
@@ -16,7 +10,7 @@ const logWithDivider = (key: string, value: LoggableValue) => {
   }
 };
 
-export const logger: LogjamFunction = (vars: string | LoggableRecord) => {
+export const log: Log = (vars: string | LoggableRecord) => {
   if (typeof vars === "string") {
     console.log("..................................");
 
@@ -30,24 +24,15 @@ export const logger: LogjamFunction = (vars: string | LoggableRecord) => {
   console.log("..................................");
 };
 
-export const useLogger: UseLogger = (vars: string | LoggableRecord) => {
-  useEffect(() => {
-    logger(vars);
-  }, [vars]);
-};
-
-// Augment globalThis type to include our logjam function
+// Augment globalThis type to include our log function
 declare global {
   interface GlobalThis {
-    logjam: LogjamFunction;
-    useLogjam: UseLogger;
+    log: Log;
   }
 }
 
 // Ensure we're in a JS environment with globalThis
 if (typeof globalThis !== "undefined") {
-  // Define the global logjam function
-  globalThis.logjam = logger;
-
-  globalThis.useLogjam = useLogger;
+  // Define the global log function
+  globalThis.log = log;
 }


### PR DESCRIPTION
## Changes

- Extract useLog hook to hooks/useLog.ts for better code organization
- Rename logjam to log throughout the codebase for consistency
- Update type definitions and imports
- Maintain global namespace functionality

## Technical Details
- Move useLog hook to a dedicated file in hooks directory
- Update type names for better clarity (LogFunction -> Log, UseLogger -> UseLog)
- Ensure all imports and type references are correctly updated
- Maintain the global registration pattern for both log and useLog
- All code passes validation, linting, and formatting checks

## Testing
✅ TypeScript checks pass
✅ ESLint validation pass
✅ Prettier formatting pass